### PR TITLE
npm package doesn't need dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "builddocs": "documentation build --config documentation.yml src/** -f html -o docs --theme docs-theme/index.js"
   },
   "devDependencies": {
+    "cdt2d": "^1.0.0",
+    "eslint": "^9.17.0",
     "@eslint/js": "^9.17.0",
     "boxen": "^8.0.1",
     "chalk": "^5.4.1",
@@ -46,9 +48,5 @@
     "highlight.js": "^11.11.0",
     "jsdoc": "^4.0.4",
     "terser": "^5.37.0"
-  },
-  "dependencies": {
-    "cdt2d": "^1.0.0",
-    "eslint": "^9.17.0"
   }
 }


### PR DESCRIPTION
I noticed that when installing phaser-box2d via npm that cdt2d and eslint were also installed. These are not required to run phaser-box2d builds though, just for development. eslint in particular adds an extra 14MB in npm packages!

This little PR fixes the issue.