### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+docs-theme
+docs
+getting-started
+overwatch
+src
+vite-template
+docs.mjs
+documentation.yml
+eslint.config.js
+jsdoc.json
+license.txt
+package-lock.json


### PR DESCRIPTION
I think offering Box2D v3 at a lightweight size is one of the big advantages of this JS port! But the npm package is a hefty 12MB.

Therefore it might be best to use an `.npmignore` file so that only the `dist` folder and only other necessary files be included in the npm package, which is more typical. If users want to get everything else they can download the git repo.
