### PR TITLE
Fix typescript regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "author": "Phaser Studio <support@phaser.io> (https://phaser.io)",
   "type": "module",
-  "types": "types",
+  "types": "types/main-prod.d.ts",
   "main": "dist/PhaserBox2D.js",
   "scripts": {
     "docs": "node docs.mjs",


### PR DESCRIPTION
Prior to merging in #9, typescript would automatically detect that the types for the entrypoint `src/main-prod.js` were found in the corresponding type declaration file `types/main-prod.d.ts`.

Since the entrypoint has changed to `dist/PhaserBox2D.js`, the type declaration entrypoint must also be explicitly set (- otherwise typescript can't find the correct matching declaration file).

This PR fixes this issue. Cheers.