### PR TITLE
Fix to b2World_CastRayClosest

### DIFF
--- a/src/world_c.js
+++ b/src/world_c.js
@@ -2620,6 +2620,7 @@ export function b2World_CastRayClosest(worldId, origin, translation, filter)
     const worldContext = new WorldRayCastContext();
     worldContext.world = world;
     worldContext.fcn = b2RayCastClosestFcn;
+    worldContext.filter = filter;
     worldContext.fraction = 1.0;
     worldContext.userContext = result;
 


### PR DESCRIPTION
Added a missing assignment to the b2World_CastRayClosest function in world_c.js. It should have been setting the query filter to the world context but instead left it null, leading to an error.