### PR TITLE
Fix to b2ShapeDistance

### DIFF
--- a/src/distance_c.js
+++ b/src/distance_c.js
@@ -395,7 +395,7 @@ function b2SolveSimplex2(s)
     {
         s.v2.a = 1.0;
         s.count = 1;
-        s.v1 = s.v2;
+        s.v1 = s.v2.clone();
 
         return;
     }

--- a/src/physics.js
+++ b/src/physics.js
@@ -353,7 +353,7 @@ let _accumulator = 0;
  * Steps a physics world to match fixedTimeStep.
  * Returns the average time spent in the step function.
  * 
- * @param {WorldConfig} data - Configuration for the world.
+ * @param {WorldStepConfig} data - Configuration for the world.
  * @returns {number} totalTime - Time spent processing the step function, in seconds.
  */
 export function WorldStep (data)

--- a/types/physics.d.ts
+++ b/types/physics.d.ts
@@ -156,10 +156,10 @@ export function CreateWorld(data: WorldConfig): {
  * Steps a physics world to match fixedTimeStep.
  * Returns the average time spent in the step function.
  *
- * @param {WorldConfig} data - Configuration for the world.
+ * @param {WorldStepConfig} data - Configuration for the world.
  * @returns {number} totalTime - Time spent processing the step function, in seconds.
  */
-export function WorldStep(data: WorldConfig): number;
+export function WorldStep(data: WorldStepConfig): number;
 /**
  * @typedef {Object} ChainConfig
  * @property {b2WorldId} worldId - ID for the world.


### PR DESCRIPTION
Added a missing .clone() in the b2Simplex2() method used by b2ShapeDistance. It was instead copying the reference from one vertex to another, causing intermittent inaccurate behaviour.