### PR TITLE
Fix to issue causing incorrect b2ShapeDistance behaviour

### DIFF
--- a/src/distance_c.js
+++ b/src/distance_c.js
@@ -395,7 +395,7 @@ function b2SolveSimplex2(s)
     {
         s.v2.a = 1.0;
         s.count = 1;
-        s.v1 = s.v2;
+        s.v1 = s.v2.clone();
 
         return;
     }


### PR DESCRIPTION
Added a missing .clone() in the b2Simplex2() method used by b2ShapeDistance. It was instead copying the reference from one vertex to another, causing intermittent inaccurate behaviour.