### PR TITLE
Fix b2World_OverlapCapsule incorrect reference to center

### DIFF
--- a/src/world_c.js
+++ b/src/world_c.js
@@ -2426,7 +2426,7 @@ export function b2World_OverlapCapsule(worldId, capsule, transform, filter, fcn,
     worldContext.world = world;
     worldContext.fcn = fcn;
     worldContext.filter = filter;
-    worldContext.proxy = b2MakeProxy(capsule.center, 2, capsule.radius);
+    worldContext.proxy = b2MakeProxy(capsule.center1, 2, capsule.radius);
     worldContext.transform = transform;
     worldContext.userContext = context;
 


### PR DESCRIPTION
This is a quick one-character fix to a broken function.

Explanation:

`b2World_OverlapCapsule` in world_c.js makes an invalid reference to a non-existent `center` property on `b2Capsule`.

The `b2Capsule` structure contains `center1` and `center2` properties, but no `center` property. (this is correct, [per the original code](https://github.com/erincatto/box2d/blob/28adacf82377d4113f2ed00586141463244b9d10/include/box2d/collision.h#L104))

The [original code](https://github.com/erincatto/box2d/blob/28adacf82377d4113f2ed00586141463244b9d10/src/world.c#L2149) for `b2World_OverlapCapsule` uses the `center1` property of the capsule instead.

This PR corrects this reference in world_c.js and brings parity to the original source.