### PR TITLE
Fix: b2CollideSegmentAndCapsule should pass manifold parameter to b2CollideCapsules

### DIFF
--- a/src/manifold_c.js
+++ b/src/manifold_c.js
@@ -773,7 +773,7 @@ export function b2CollideSegmentAndCapsule(segmentA, xfA, capsuleB, xfB, manifol
     constCapsule.center2 = segmentA.point2;
     constCapsule.radius = 0;
 
-    return b2CollideCapsules(constCapsule, xfA, capsuleB, xfB);
+    return b2CollideCapsules(constCapsule, xfA, capsuleB, xfB, manifold);
 }
 
 /**
@@ -1970,7 +1970,7 @@ export function b2CollideChainSegmentAndPolygon(chainSegmentA, xfA, polygonB, xf
             {
                 if (b2Dot(n2, n) < b2Dot(normal1, n))
                 {
-                    return manifold.clear(0);
+                    return manifold.clear();
                 }
             }
 


### PR DESCRIPTION
This PR fixes the `b2CollideSegmentAndCapsule` function.

**Explanation:**

It seems to me that `b2CollideCapsules` was changed from [the original](https://github.com/erincatto/box2d/blob/28adacf82377d4113f2ed00586141463244b9d10/src/manifold.c#L260) in that it performs an in-place modification of the `manifold` parameter, rather than creating & returning a new one. (I assume this is for performance reasons?)

However, it looks like `b2CollideSegmentAndCapsule`, a function which was [also modified from the original](https://github.com/erincatto/box2d/blob/28adacf82377d4113f2ed00586141463244b9d10/src/manifold.c#L529) (seemingly with the same intent), does not correctly pass the manifold parameter through to the `b2CollideCapsules` function it depends upon.

This fixes that.

**Additionally:**

This also corrects an erroneous call to `manifold.clear()` with a parameter (0) which is seemingly inert and unnecessary, as this function does not accept any parameters.