### PR TITLE
Fix/vite template to work out of the box and remove initial errors 

### DIFF
--- a/vite-template/jsconfig.json
+++ b/vite-template/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  }
+}

--- a/vite-template/src/main.js
+++ b/vite-template/src/main.js
@@ -1,6 +1,6 @@
 import * as Phaser from 'phaser';
 
-import { AddSpriteToWorld, CreateBoxPolygon, CreateWorld, STATIC, SetWorldScale, SpriteToBox, UpdateWorldSprites, WorldStep, b2DefaultBodyDef, b2DefaultWorldDef, b2Vec2, pxmVec2 } from './PhaserBox2D-Release.js';
+import { AddSpriteToWorld, CreateBoxPolygon, CreateWorld, STATIC, SetWorldScale, SpriteToBox, UpdateWorldSprites, WorldStep, b2DefaultBodyDef, b2DefaultWorldDef, b2Vec2, pxmVec2 } from './PhaserBox2D.js';
 
 class Example extends Phaser.Scene
 {


### PR DESCRIPTION
This PR adds a new tsconfig file within the vite-template folder to enable the vite dev and build commands to work correctly. 
I also edited the main.js file to correctly use the bundled PhaserBox2D.js file instead of looking for PhaserBox2D-release.js