### PR TITLE
fix lowerImpulse to upperImpulse

### DIFF
--- a/src/revolute_joint_c.js
+++ b/src/revolute_joint_c.js
@@ -592,7 +592,7 @@ export function b2SolveRevoluteJoint(base, context, useBias)
 
             // sign flipped on Cdot
             const Cdot = wA - wB;
-            let impulse = -massScale * joint.axialMass * (Cdot + bias) - impulseScale * joint.lowerImpulse;
+            let impulse = -massScale * joint.axialMass * (Cdot + bias) - impulseScale * joint.upperImpulse;
             const oldImpulse = joint.upperImpulse;
             joint.upperImpulse = Math.max(joint.upperImpulse + impulse, 0.0);
             impulse = joint.upperImpulse - oldImpulse;


### PR DESCRIPTION
Thanks to phaser for providing the js version of box2d version 3.
When I used RevoluteJoint, the calculation results of left turn and right turn were inconsistent. After checking the code, I found that it was due to variable errors. Here lowerImpulse should be upperImpulse.
In addition, I found that the original version of box2d 3.1.1 has also modified the variables here.